### PR TITLE
add split module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
         "irspack.dataset",
         "irspack.dataset.movielens",
         # "irspack.item_cold_start",
+        "irspack.split",
         "irspack.utils",
         "irspack.utils.encoders",
     ],


### PR DESCRIPTION
irspack.split モジュールが package に含まれていないので追加しました。
動作確認で、pytest と examples/movielens/movielens_1m.py で正常に動作することを確認しました。