### PR TITLE
threading behavior changed.

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run pytest
         run: |
           pip install pytest pytest-cov
-          pip install lightfm jaxlib==0.1.57 jax dm-haiku optax
+          pip install lightfm jaxlib jax dm-haiku optax
           pytest --cov=./irspack tests/
       - name: Generate coverage (ubuntu)
         run: |

--- a/examples/evaluate-recommender.ipynb
+++ b/examples/evaluate-recommender.ipynb
@@ -65,9 +65,7 @@
     "\n",
     "![Perform hold out for all users.](./split1.png \"split1\")\n",
     "\n",
-    "We have prepared a fast implementaion of such a split (with random selection of these subset) in ``rowwise_train_test_split`` function.\n",
-    "\n",
-    "This scheme however has a problem regarding the performance because we have to compute the recommendation score for all the users. So in the next tutorial, we will be using a sub-sampled version of this splitting."
+    "We have prepared a fast implementaion of such a split (with random selection of these subset) in ``rowwise_train_test_split`` function:"
    ]
   },
   {
@@ -76,15 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train, X_valid = rowwise_train_test_split(X, test_ratio=0.2, random_seed=0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "X_train, X_valid = rowwise_train_test_split(X, test_ratio=0.2, random_seed=0)\n",
+    "\n",
     "assert X_train.shape == X_valid.shape"
    ]
   },
@@ -92,7 +83,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "They sum back to the original matrix."
+    "They sum back to the original matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<6040x3706 sparse matrix of type '<class 'numpy.float64'>'\n",
+       "\twith 0 stored elements in Compressed Sparse Row format>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X - (X_train + X_valid) # 0 stored elements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is no overlap of non-zero elements:"
    ]
   },
   {
@@ -113,35 +132,14 @@
     }
    ],
    "source": [
-    "X - (X_train + X_valid) # 0 stored elements"
+    "X_train.multiply(X_valid) # Element-wise multiplication yields 0 stored elements"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is no overlap of non-zero elements."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<6040x3706 sparse matrix of type '<class 'numpy.float64'>'\n",
-       "\twith 0 stored elements in Compressed Sparse Row format>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_train.multiply(X_valid) # Element-wise multiplication yields 0 stored elements"
+    "This scheme however has a problem regarding the performance because we have to compute the recommendation score for all the users. So in the next tutorial, we will be using a sub-sampled version of this splitting."
    ]
   },
   {
@@ -156,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,29 +173,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "OrderedDict([('hit@5', 0.7935430463576159),\n",
-       "             ('recall@5', 0.09357329074754922),\n",
-       "             ('ndcg@5', 0.39936130766343314),\n",
-       "             ('map@5', 0.06671765815079544),\n",
+       "             ('recall@5', 0.09357329074754896),\n",
+       "             ('ndcg@5', 0.39936130766343303),\n",
+       "             ('map@5', 0.06671765815079535),\n",
+       "             ('precision@5', 0.37695364238410584),\n",
        "             ('gini_index@5', 0.9737846091714528),\n",
        "             ('entropy@5', 4.791553116972738),\n",
        "             ('appeared_item@5', 545.0),\n",
        "             ('hit@10', 0.8966887417218543),\n",
-       "             ('recall@10', 0.15261650834932203),\n",
-       "             ('ndcg@10', 0.3697677997781827),\n",
-       "             ('map@10', 0.09057228932779289),\n",
+       "             ('recall@10', 0.1526165083493217),\n",
+       "             ('ndcg@10', 0.3697677997781819),\n",
+       "             ('map@10', 0.09057228932779285),\n",
+       "             ('precision@10', 0.3239072847682119),\n",
        "             ('gini_index@10', 0.9613104845194654),\n",
-       "             ('entropy@10', 5.199571410742591),\n",
+       "             ('entropy@10', 5.199571410742589),\n",
        "             ('appeared_item@10', 771.0)])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -225,29 +225,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "OrderedDict([('hit@5', 0.5319536423841059),\n",
-       "             ('recall@5', 0.03990291401117003),\n",
-       "             ('ndcg@5', 0.21637600397711307),\n",
-       "             ('map@5', 0.02510759708371324),\n",
+       "             ('recall@5', 0.03990291401116996),\n",
+       "             ('ndcg@5', 0.21637600397711287),\n",
+       "             ('map@5', 0.025107597083713212),\n",
+       "             ('precision@5', 0.20649006622516558),\n",
        "             ('gini_index@5', 0.997223564436407),\n",
        "             ('entropy@5', 2.6085822508131637),\n",
        "             ('appeared_item@5', 43.0),\n",
        "             ('hit@10', 0.6614238410596026),\n",
-       "             ('recall@10', 0.06688199444797117),\n",
-       "             ('ndcg@10', 0.2004243718788812),\n",
-       "             ('map@10', 0.033385869291721104),\n",
+       "             ('recall@10', 0.06688199444797102),\n",
+       "             ('ndcg@10', 0.20042437187888076),\n",
+       "             ('map@10', 0.03338586929172107),\n",
+       "             ('precision@10', 0.18096026490066222),\n",
        "             ('gini_index@10', 0.9950121246019521),\n",
        "             ('entropy@10', 3.179463712641221),\n",
        "             ('appeared_item@10', 65.0)])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/hyperparameter-optimization.ipynb
+++ b/examples/hyperparameter-optimization.ipynb
@@ -19,8 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
     "import numpy as np\n",
     "import scipy.sparse as sps\n",
     "from sklearn.model_selection import train_test_split\n",
@@ -36,24 +34,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The comptutation might be heavy, so we use multiple threads to speed up the training and evaluation.\n",
-    "\n",
-    "You can tell our algorithms to use mutiple threads whenever possible by setting ``IRSPACK_NUM_THREADS_DEFAULT`` environment variable:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"IRSPACK_NUM_THREADS_DEFAULT\"] = \"8\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Read the ML1M dataset again.\n",
     "\n",
     "We again prepare the sparse matrix `X`."
@@ -61,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,16 +159,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.5190536602989886"
+       "0.5201847872700308"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +192,7 @@
     {
      "data": {
       "text/plain": [
-       "{'alpha': 5.063313369473015e-07, 'top_k': 161, 'normalize_weight': False}"
+       "{'top_k': 168, 'normalize_weight': False}"
       ]
      },
      "execution_count": 8,
@@ -229,7 +209,7 @@
    "metadata": {},
    "source": [
     "Meanwhile, the default argument of ``P3alphaRecommdner`` (which has been used so far)\n",
-    "attains `ndcg@20` = 0.404. So this is indeed a significant improvement:"
+    "attains `ndcg@20` = 0.403. So this is indeed a significant improvement:"
    ]
   },
   {
@@ -240,7 +220,7 @@
     {
      "data": {
       "text/plain": [
-       "0.4041442008349765"
+       "0.40295209930702075"
       ]
      },
      "execution_count": 9,
@@ -447,9 +427,9 @@
     {
      "data": {
       "text/plain": [
-       "{'train': <irspack.split.random.UserTrainTestInteractionPair at 0x7fa11bdffb50>,\n",
-       " 'val': <irspack.split.random.UserTrainTestInteractionPair at 0x7fa11bdff410>,\n",
-       " 'test': <irspack.split.random.UserTrainTestInteractionPair at 0x7fa11c9e8f10>}"
+       "{'train': <irspack.split.random.UserTrainTestInteractionPair at 0x7fd1420a33d0>,\n",
+       " 'val': <irspack.split.random.UserTrainTestInteractionPair at 0x7fd1420ab750>,\n",
+       " 'test': <irspack.split.random.UserTrainTestInteractionPair at 0x7fd1420a1450>}"
       ]
      },
      "execution_count": 12,
@@ -613,49 +593,49 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "valid_score=0.42824183005121735:  11%|█         | 55/512 [00:05<00:45,  9.96it/s]\n",
-      "valid_score=0.40060602861013855:  15%|█▍        | 75/512 [00:09<00:52,  8.37it/s]\n",
-      "valid_score=0.5333345981232733:  14%|█▎        | 70/512 [00:02<00:17, 25.95it/s]\n",
-      "valid_score=0.4565719212930136:   7%|▋         | 35/512 [00:02<00:40, 11.79it/s] \n",
-      "valid_score=0.48549781083236443:   8%|▊         | 40/512 [00:02<00:31, 14.81it/s]\n",
-      "valid_score=0.5327950253455304:  10%|▉         | 50/512 [00:01<00:17, 25.96it/s]\n",
-      "valid_score=0.4767790510450989:   7%|▋         | 35/512 [00:02<00:38, 12.30it/s] \n",
-      "valid_score=0.4078509330631947:   1%|          | 5/512 [00:00<00:34, 14.61it/s]\n",
-      "valid_score=0.4372874728149235:   1%|          | 5/512 [00:00<00:53,  9.40it/s]\n",
-      "valid_score=0.4217175292017891:   1%|          | 5/512 [00:00<00:46, 10.97it/s]\n",
-      "valid_score=0.44462285171408994:   1%|          | 5/512 [00:00<00:14, 35.51it/s]\n",
-      "valid_score=0.5299876125954996:   9%|▉         | 45/512 [00:01<00:17, 27.08it/s]\n",
-      "valid_score=0.5338013123443506:  14%|█▎        | 70/512 [00:03<00:19, 22.57it/s]\n",
-      "valid_score=0.5273331792612119:   7%|▋         | 35/512 [00:01<00:21, 22.01it/s]\n",
-      "valid_score=0.5286246823761697:   7%|▋         | 35/512 [00:01<00:22, 21.25it/s]\n",
-      "valid_score=0.5264078529929245:   7%|▋         | 35/512 [00:01<00:22, 21.03it/s]\n",
-      "valid_score=0.44400466852940296:   1%|          | 5/512 [00:00<00:14, 36.19it/s]\n",
-      "valid_score=0.5306979586892263:   8%|▊         | 40/512 [00:01<00:16, 27.96it/s]\n",
-      "valid_score=0.511043342238914:   7%|▋         | 35/512 [00:02<00:27, 17.24it/s] \n",
-      "valid_score=0.4518078505781681:   1%|          | 5/512 [00:00<00:27, 18.14it/s]\n",
-      "valid_score=0.533190381872124:  12%|█▏        | 60/512 [00:02<00:19, 23.58it/s] \n",
-      "valid_score=0.5330299634914348:  10%|▉         | 50/512 [00:02<00:17, 25.86it/s]\n",
-      "valid_score=0.5018637442329386:   1%|          | 5/512 [00:00<00:15, 33.50it/s]\n",
-      "valid_score=0.5030662041498615:   1%|          | 5/512 [00:00<00:28, 17.81it/s]\n",
-      "valid_score=0.5289883633577348:   2%|▏         | 10/512 [00:00<00:18, 27.63it/s]\n",
-      "valid_score=0.49958073757480104:   1%|          | 5/512 [00:00<00:18, 27.99it/s]\n",
-      "valid_score=0.5123500965698433:   1%|          | 5/512 [00:00<00:25, 19.92it/s]\n",
-      "valid_score=0.5345384958248065:  12%|█▏        | 60/512 [00:02<00:19, 23.70it/s]\n",
-      "valid_score=0.49529533153445293:   1%|          | 5/512 [00:00<00:32, 15.41it/s]\n",
-      "valid_score=0.5034195494138344:   1%|          | 5/512 [00:00<00:16, 29.90it/s]\n",
-      "valid_score=0.37982336414616824:   1%|          | 5/512 [00:00<00:29, 17.36it/s]\n",
-      "valid_score=0.5341290557392615:  15%|█▍        | 75/512 [00:03<00:18, 23.60it/s]\n",
-      "valid_score=0.5330484337350391:   8%|▊         | 40/512 [00:01<00:19, 24.80it/s]\n",
-      "valid_score=0.5169060070657032:   1%|          | 5/512 [00:00<00:25, 20.08it/s]\n",
-      "valid_score=0.535784217748701:  11%|█         | 55/512 [00:02<00:19, 23.77it/s] \n",
-      "valid_score=0.5350593666909814:   9%|▉         | 45/512 [00:01<00:17, 27.38it/s]\n",
-      "valid_score=0.5164001692167451:   1%|          | 5/512 [00:00<00:16, 31.61it/s]\n",
-      "valid_score=0.5346230124782899:  15%|█▍        | 75/512 [00:02<00:15, 27.92it/s]/home/tomoki/.pyenv/versions/3.7.4/envs/main/lib/python3.7/site-packages/numpy/lib/nanfunctions.py:1366: RuntimeWarning: Mean of empty slice\n",
+      "valid_score=0.4286177452510083:  11%|█         | 55/512 [00:03<00:31, 14.56it/s] \n",
+      "valid_score=0.4006716297870051:  16%|█▌        | 80/512 [00:07<00:38, 11.28it/s] \n",
+      "valid_score=0.5333345473162197:  14%|█▎        | 70/512 [00:01<00:11, 37.93it/s]\n",
+      "valid_score=0.4566541653672858:   7%|▋         | 35/512 [00:01<00:27, 17.55it/s] \n",
+      "valid_score=0.48549460549480716:   8%|▊         | 40/512 [00:01<00:20, 23.41it/s]\n",
+      "valid_score=0.532794330135122:  10%|▉         | 50/512 [00:01<00:11, 40.72it/s] \n",
+      "valid_score=0.47677713049745984:   7%|▋         | 35/512 [00:01<00:25, 18.55it/s]\n",
+      "valid_score=0.4077279482503446:   1%|          | 5/512 [00:00<00:20, 24.39it/s]\n",
+      "valid_score=0.43724247309531833:   1%|          | 5/512 [00:00<00:40, 12.59it/s]\n",
+      "valid_score=0.421632099259319:   1%|          | 5/512 [00:00<00:30, 16.49it/s]\n",
+      "valid_score=0.44462285171408983:   1%|          | 5/512 [00:00<00:09, 51.17it/s]\n",
+      "valid_score=0.5299872810504818:   9%|▉         | 45/512 [00:01<00:11, 40.86it/s]\n",
+      "valid_score=0.5337418814380109:  14%|█▎        | 70/512 [00:02<00:13, 32.82it/s]\n",
+      "valid_score=0.5272983863433538:   7%|▋         | 35/512 [00:01<00:17, 26.78it/s]\n",
+      "valid_score=0.528669300497682:   7%|▋         | 35/512 [00:01<00:15, 30.67it/s] \n",
+      "valid_score=0.5264231414370675:   7%|▋         | 35/512 [00:01<00:15, 30.73it/s]\n",
+      "valid_score=0.44400466852940307:   1%|          | 5/512 [00:00<00:10, 49.30it/s]\n",
+      "valid_score=0.5306830383486534:   8%|▊         | 40/512 [00:00<00:11, 40.93it/s]\n",
+      "valid_score=0.5109723411572203:   7%|▋         | 35/512 [00:01<00:17, 26.61it/s]\n",
+      "valid_score=0.45174997531386657:   1%|          | 5/512 [00:00<00:23, 21.54it/s]\n",
+      "valid_score=0.5331970252208796:  12%|█▏        | 60/512 [00:01<00:12, 35.06it/s]\n",
+      "valid_score=0.5339062819636539:   8%|▊         | 40/512 [00:01<00:13, 34.51it/s]\n",
+      "valid_score=0.5018629810737998:   1%|          | 5/512 [00:00<00:10, 46.46it/s]\n",
+      "valid_score=0.5029801792957225:   1%|          | 5/512 [00:00<00:21, 23.82it/s]\n",
+      "valid_score=0.5290095318467676:   2%|▏         | 10/512 [00:00<00:14, 35.04it/s]\n",
+      "valid_score=0.4996060160225889:   1%|          | 5/512 [00:00<00:12, 42.13it/s]\n",
+      "valid_score=0.5122197001022162:   1%|          | 5/512 [00:00<00:16, 29.89it/s]\n",
+      "valid_score=0.5345774393811206:  12%|█▏        | 60/512 [00:01<00:12, 34.85it/s]\n",
+      "valid_score=0.49528773445573965:   1%|          | 5/512 [00:00<00:20, 24.24it/s]\n",
+      "valid_score=0.5034034262525362:   1%|          | 5/512 [00:00<00:11, 44.55it/s]\n",
+      "valid_score=0.3800035907397823:   1%|          | 5/512 [00:00<00:20, 24.66it/s]\n",
+      "valid_score=0.5341294237286196:  16%|█▌        | 80/512 [00:02<00:12, 34.99it/s]\n",
+      "valid_score=0.533050752007142:   8%|▊         | 40/512 [00:01<00:13, 35.97it/s] \n",
+      "valid_score=0.5168843215502895:   1%|          | 5/512 [00:00<00:17, 29.30it/s]\n",
+      "valid_score=0.5358016852380528:  11%|█         | 55/512 [00:01<00:12, 36.16it/s]\n",
+      "valid_score=0.5350634925337578:   9%|▉         | 45/512 [00:01<00:12, 37.31it/s]\n",
+      "valid_score=0.5164197584533197:   1%|          | 5/512 [00:00<00:11, 43.63it/s]\n",
+      "valid_score=0.5348826944554491:  16%|█▌        | 80/512 [00:01<00:10, 40.82it/s]/home/tomoki/.pyenv/versions/main/lib/python3.7/site-packages/numpy/lib/nanfunctions.py:1366: RuntimeWarning: Mean of empty slice\n",
       "  return np.nanmean(a, axis, out=out, keepdims=keepdims)\n",
-      "valid_score=0.5348182715646398:  18%|█▊        | 90/512 [00:03<00:15, 27.65it/s]\n",
-      "valid_score=0.5305485694376337:   2%|▏         | 10/512 [00:00<00:17, 28.12it/s]\n",
-      "valid_score=0.46877847228072783:   1%|          | 5/512 [00:00<00:15, 33.77it/s]\n",
-      "100%|██████████| 20/20 [00:00<00:00, 32.61it/s]\n"
+      "valid_score=0.5348143117469335:  18%|█▊        | 90/512 [00:02<00:10, 41.07it/s]\n",
+      "valid_score=0.5305382424324274:   2%|▏         | 10/512 [00:00<00:11, 44.18it/s]\n",
+      "valid_score=0.46878113344335887:   1%|          | 5/512 [00:00<00:11, 42.63it/s]\n",
+      "100%|██████████| 20/20 [00:00<00:00, 56.47it/s]\n"
      ]
     },
     {
@@ -748,49 +728,49 @@
        "      <th>0</th>\n",
        "      <td>IALSOptimizer</td>\n",
        "      <td>0.993929</td>\n",
-       "      <td>0.201032</td>\n",
-       "      <td>0.549493</td>\n",
-       "      <td>0.128710</td>\n",
-       "      <td>0.498317</td>\n",
-       "      <td>0.914696</td>\n",
-       "      <td>5.994704</td>\n",
+       "      <td>0.201026</td>\n",
+       "      <td>0.549464</td>\n",
+       "      <td>0.128704</td>\n",
+       "      <td>0.498289</td>\n",
+       "      <td>0.914690</td>\n",
+       "      <td>5.994786</td>\n",
        "      <td>994.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>RP3betaOptimizer</td>\n",
-       "      <td>0.995033</td>\n",
-       "      <td>0.193559</td>\n",
-       "      <td>0.537777</td>\n",
-       "      <td>0.123390</td>\n",
-       "      <td>0.484078</td>\n",
-       "      <td>0.949540</td>\n",
-       "      <td>5.409107</td>\n",
-       "      <td>982.0</td>\n",
+       "      <td>0.993929</td>\n",
+       "      <td>0.195581</td>\n",
+       "      <td>0.538921</td>\n",
+       "      <td>0.123981</td>\n",
+       "      <td>0.485955</td>\n",
+       "      <td>0.943677</td>\n",
+       "      <td>5.511911</td>\n",
+       "      <td>1089.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>P3alphaOptimizer</td>\n",
-       "      <td>0.990066</td>\n",
-       "      <td>0.186035</td>\n",
-       "      <td>0.522004</td>\n",
-       "      <td>0.116442</td>\n",
-       "      <td>0.469812</td>\n",
-       "      <td>0.962653</td>\n",
-       "      <td>5.146738</td>\n",
-       "      <td>667.0</td>\n",
+       "      <td>0.990618</td>\n",
+       "      <td>0.185090</td>\n",
+       "      <td>0.520921</td>\n",
+       "      <td>0.115644</td>\n",
+       "      <td>0.468874</td>\n",
+       "      <td>0.964735</td>\n",
+       "      <td>5.092836</td>\n",
+       "      <td>637.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>DenseSLIMOptimizer</td>\n",
        "      <td>0.993929</td>\n",
-       "      <td>0.210865</td>\n",
-       "      <td>0.574984</td>\n",
-       "      <td>0.139570</td>\n",
-       "      <td>0.520006</td>\n",
-       "      <td>0.928136</td>\n",
-       "      <td>5.807884</td>\n",
-       "      <td>988.0</td>\n",
+       "      <td>0.210931</td>\n",
+       "      <td>0.575348</td>\n",
+       "      <td>0.139585</td>\n",
+       "      <td>0.520337</td>\n",
+       "      <td>0.928750</td>\n",
+       "      <td>5.799377</td>\n",
+       "      <td>981.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -798,16 +778,16 @@
       ],
       "text/plain": [
        "            algorithm    hit@20  recall@20   ndcg@20    map@20  precision@20  \\\n",
-       "0       IALSOptimizer  0.993929   0.201032  0.549493  0.128710      0.498317   \n",
-       "1    RP3betaOptimizer  0.995033   0.193559  0.537777  0.123390      0.484078   \n",
-       "2    P3alphaOptimizer  0.990066   0.186035  0.522004  0.116442      0.469812   \n",
-       "3  DenseSLIMOptimizer  0.993929   0.210865  0.574984  0.139570      0.520006   \n",
+       "0       IALSOptimizer  0.993929   0.201026  0.549464  0.128704      0.498289   \n",
+       "1    RP3betaOptimizer  0.993929   0.195581  0.538921  0.123981      0.485955   \n",
+       "2    P3alphaOptimizer  0.990618   0.185090  0.520921  0.115644      0.468874   \n",
+       "3  DenseSLIMOptimizer  0.993929   0.210931  0.575348  0.139585      0.520337   \n",
        "\n",
        "   gini_index@20  entropy@20  appeared_item@20  \n",
-       "0       0.914696    5.994704             994.0  \n",
-       "1       0.949540    5.409107             982.0  \n",
-       "2       0.962653    5.146738             667.0  \n",
-       "3       0.928136    5.807884             988.0  "
+       "0       0.914690    5.994786             994.0  \n",
+       "1       0.943677    5.511911            1089.0  \n",
+       "2       0.964735    5.092836             637.0  \n",
+       "3       0.928750    5.799377             981.0  "
       ]
      },
      "execution_count": 20,
@@ -823,9 +803,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7.4 64-bit ('main': venv)",
    "language": "python",
-   "name": "python3"
+   "name": "python37464bitmainvenv859a67c34419467482ffa49e17018b99"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/movielens/movielens_1m.py
+++ b/examples/movielens/movielens_1m.py
@@ -20,9 +20,6 @@ from irspack.optimizers import (  # BPRFMOptimizer, #requires lightFM; MultVAEOp
 )
 from irspack.split import split_dataframe_partial_user_holdout
 
-os.environ["OMP_NUM_THREADS"] = "8"
-os.environ["IRSPACK_NUM_THREADS_DEFAULT"] = "8"
-
 if __name__ == "__main__":
 
     BASE_CUTOFF = 20

--- a/examples/movielens/movielens_1m_cold.py
+++ b/examples/movielens/movielens_1m_cold.py
@@ -1,6 +1,4 @@
 import json
-import logging
-import os
 from typing import List, Tuple, Type
 
 import pandas as pd
@@ -20,9 +18,6 @@ from irspack.optimizers import (  # SLIMOptimizer,; MultVAEOptimizer,
     TverskyIndexKNNOptimizer,
 )
 from irspack.split import split_dataframe_partial_user_holdout
-
-os.environ["OMP_NUM_THREADS"] = "8"
-os.environ["IRSPACK_NUM_THREADS_DEFAULT"] = "8"
 
 if __name__ == "__main__":
 

--- a/examples/movielens/movielens_1m_user_cold_start.py
+++ b/examples/movielens/movielens_1m_user_cold_start.py
@@ -10,7 +10,6 @@ CB2CF Requires the following additional dependencies to run.
 
 """
 import json
-import os
 from typing import Any, Dict, List, Tuple, Type
 
 import numpy as np
@@ -35,10 +34,6 @@ from irspack.utils.encoders import (
     CategoricalValueEncoder,
     DataFrameEncoder,
 )
-
-os.environ["OMP_NUM_THREADS"] = "8"
-os.environ["IRSPACK_NUM_THREADS_DEFAULT"] = "8"
-
 
 if __name__ == "__main__":
     BASE_CUTOFF = 20

--- a/examples/movielens/movielens_20m_cold.py
+++ b/examples/movielens/movielens_20m_cold.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Any, Dict, List, Tuple, Type
 
 import pandas as pd
@@ -20,15 +19,6 @@ from irspack.optimizers import (
     TopPopOptimizer,
 )
 from irspack.split import split_dataframe_partial_user_holdout
-
-N_CPUS = os.cpu_count()
-if N_CPUS is None:
-    N_CPUS = 1
-os.environ["OMP_NUM_THREADS"] = str(N_CPUS)
-
-# This will set the number of thread to be N_CPUS where it is possible.
-# You can also controll the number of threads for each recommender.
-os.environ["IRSPACK_NUM_THREADS_DEFAULT"] = str(N_CPUS)
 
 if __name__ == "__main__":
 
@@ -88,7 +78,7 @@ if __name__ == "__main__":
                 dim_z=200, enc_hidden_dims=600, kl_anneal_goal=0.2
             ),  # nothing to tune, use the parameters used in the paper.
         ),
-        # (SLIMOptimizer, 40, dict()), # Note: this is a heavy one.
+        (SLIMOptimizer, 40, dict()),  # Note: this is a heavy one.
     ]
     for optimizer_class, n_trials, config in test_configs:
         recommender_name = optimizer_class.recommender_class.__name__

--- a/irspack/evaluator.py
+++ b/irspack/evaluator.py
@@ -62,7 +62,7 @@ class Evaluator:
         n_threads (int, optional):
             Specifies the Number of threads to sort scores and compute the evaluation metrics.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
         mb_size (int, optional):
             The rows of chunked user score. Defaults to 1024.
     """
@@ -207,7 +207,7 @@ class EvaluatorWithColdUser(Evaluator):
         n_threads (int, optional):
             Specifies the Number of threads to sort scores and compute the evaluation metrics.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
         mb_size (int, optional):
             The rows of chunked user score. Defaults to 1024.
     """

--- a/irspack/recommenders/bpr.py
+++ b/irspack/recommenders/bpr.py
@@ -83,7 +83,7 @@ class BPRFMRecommender(
             Maximal number of allowed score degradation. Defaults to 5.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
         max_epoch (int, optional):
             Maximal number of epochs. Defaults to 512.
     """

--- a/irspack/recommenders/ials.py
+++ b/irspack/recommenders/ials.py
@@ -102,7 +102,7 @@ class IALSRecommender(
         n_threads (Optional[int], optional):
             Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
         max_epoch (int, optional):
             Maximal number of epochs. Defaults to 512.
     """

--- a/irspack/recommenders/knn.py
+++ b/irspack/recommenders/knn.py
@@ -98,7 +98,7 @@ class CosineKNNRecommender(BaseKNNRecommender):
             The b parameter for BM25. Ignored if ``feature_weighting`` is not "BM_25". Defaults to 0.75.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
 
     """
 
@@ -161,7 +161,7 @@ class AsymmetricCosineKNNRecommender(BaseKNNRecommender):
             The b parameter for BM25. Ignored if ``feature_weighting`` is not "BM_25". Defaults to 0.75.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
 
     """
 
@@ -209,7 +209,7 @@ class JaccardKNNRecommender(BaseKNNRecommender):
             Specifies the maximal number of allowed neighbors. Defaults to 100.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
 
     """
 
@@ -246,7 +246,7 @@ class TverskyIndexKNNRecommender(BaseKNNRecommender):
             Specifies the maximal number of allowed neighbors. Defaults to 100.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
 
     """
 

--- a/irspack/recommenders/p3.py
+++ b/irspack/recommenders/p3.py
@@ -33,7 +33,7 @@ class P3alphaRecommender(BaseSimilarityRecommender):
             Defaults to False.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
     def __init__(

--- a/irspack/recommenders/rp3.py
+++ b/irspack/recommenders/rp3.py
@@ -34,7 +34,7 @@ class RP3betaRecommender(BaseSimilarityRecommender):
             Defaults to False.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
     def __init__(

--- a/irspack/recommenders/slim.py
+++ b/irspack/recommenders/slim.py
@@ -36,7 +36,7 @@ class SLIMRecommender(BaseSimilarityRecommender):
         n_threads:
             Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
     def __init__(

--- a/irspack/recommenders/user_knn.py
+++ b/irspack/recommenders/user_knn.py
@@ -98,7 +98,7 @@ class CosineUserKNNRecommender(BaseUserKNNRecommender):
             The b parameter for BM25. Ignored if ``feature_weighting`` is not "BM_25". Defaults to 0.75.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
     def __init__(
@@ -159,7 +159,7 @@ class AsymmetricCosineUserKNNRecommender(BaseUserKNNRecommender):
             The b parameter for BM25. Ignored if ``feature_weighting`` is not "BM_25". Defaults to 0.75.
         n_threads (Optional[int], optional): Specifies the number of threads to use for the computation.
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
-            and if there is no such an environment variable, it will be set to 1. Defaults to None.
+            and if there is no such an environment variable, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
     def __init__(

--- a/irspack/utils/__init__.py
+++ b/irspack/utils/__init__.py
@@ -65,8 +65,10 @@ def get_n_threads(n_threads: Optional[int]) -> int:
         return n_threads
     else:
         try:
-            n_threads = int(os.environ.get("IRSPACK_NUM_THREADS_DEFAULT", "1"))
-            return n_threads
+            n_threads_cand = os.environ.get(
+                "IRSPACK_NUM_THREADS_DEFAULT", os.cpu_count()
+            )
+            return int(n_threads_cand or 1)
         except:
             raise ValueError(
                 'failed to interpret "IRSPACK_NUM_THREADS_DEFAULT" as an integer.'

--- a/tests/recommenders/test_knn.py
+++ b/tests/recommenders/test_knn.py
@@ -232,4 +232,4 @@ def test_n_threads(X: sps.csr_matrix) -> None:
         rec = CosineKNNRecommender(X)
     os.environ.pop("IRSPACK_NUM_THREADS_DEFAULT")
     rec = CosineKNNRecommender(X)
-    assert rec.n_threads == 1
+    assert rec.n_threads == (os.cpu_count() or 1)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -21,15 +21,14 @@ X_array = X.toarray()
 def test_sparse_mm_threaded() -> None:
     X_mm = sparse_mm_threaded(X, X.T, 3).toarray()
     X_sps = X.dot(X.T).toarray()
-    X_diff = X_mm - X_sps
-    assert np.all(X_diff == 0)
+    np.testing.assert_allclose(X_mm, X_sps)
 
 
 def test_split() -> None:
     warnings.simplefilter("always")
 
     X_1, X_2 = rowwise_train_test_split(X, test_ratio=0.5, random_seed=1)
-    assert np.all((X - X_1 - X_2).toarray() == 0)
+    np.testing.assert_allclose(X.toarray(), (X_1 + X_2).toarray())
 
     # should have no overwrap
     assert np.all(X_1.multiply(X_2).toarray() == 0)
@@ -59,4 +58,4 @@ def test_tf_idf() -> None:
         X.toarray() * np.log(X.shape[0] / (1 + np.bincount(X.nonzero()[1])))[None, :]
     )
     X_tf_idf = tf_idf_weight(X).toarray()
-    assert np.all((X_manual - X_tf_idf) == 0.0)
+    np.testing.assert_allclose(X_manual, X_tf_idf)


### PR DESCRIPTION
Use ``os.cpu_count()`` by default so that the users can exploit the CPU cores without referring to envvar.