### PR TITLE
Evaluator mask arbitrary (#52)

### DIFF
--- a/create_pb_stubs.sh
+++ b/create_pb_stubs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 modules=( \
 "irspack.recommenders._ials" \
-"irspack._evaluator" \
+"irspack.evaluator._core" \
 "irspack.recommenders._knn" \
 "irspack.utils._util_cpp"
 )

--- a/irspack/evaluator/__init__.py
+++ b/irspack/evaluator/__init__.py
@@ -1,0 +1,11 @@
+from ._core import EvaluatorCore, Metrics
+from .evaluator import METRIC_NAMES, Evaluator, EvaluatorWithColdUser, TargetMetric
+
+__all__ = [
+    "Evaluator",
+    "Metrics",
+    "TargetMetric",
+    "METRIC_NAMES",
+    "EvaluatorCore",
+    "EvaluatorWithColdUser",
+]

--- a/irspack/evaluator/_core.pyi
+++ b/irspack/evaluator/_core.pyi
@@ -2,7 +2,7 @@ m: int
 n: int
 from numpy import float32
 
-import irspack._evaluator
+import irspack.evaluator._core
 from typing import *
 from typing import Iterable as iterable
 from typing import Iterator as iterator

--- a/irspack/optimizers/base_optimizer.py
+++ b/irspack/optimizers/base_optimizer.py
@@ -145,7 +145,7 @@ class BaseOptimizer(object, metaclass=ABCMeta):
                 score,
                 time_spent,
             )
-            val_score = score[self.val_evaluator.target_metric.value]
+            val_score = score[self.val_evaluator.target_metric.name]
             if (-val_score) < self.best_val:
                 self.best_val = -val_score
                 self.best_time = time_spent

--- a/irspack/recommenders/base.py
+++ b/irspack/recommenders/base.py
@@ -109,8 +109,6 @@ class BaseRecommender(object, metaclass=ABCMeta):
             scores = scores.toarray()
         m = self.X_train_all[user_indices].tocsr()
         scores[m.nonzero()] = -np.inf
-        if scores.dtype != np.float64:
-            scores = scores.astype(np.float64)
         return scores
 
     def get_score_remove_seen_block(self, begin: int, end: int) -> DenseScoreArray:
@@ -126,8 +124,6 @@ class BaseRecommender(object, metaclass=ABCMeta):
         scores = _sparse_to_array(self.get_score_block(begin, end))
         m = self.X_train_all[begin:end]
         scores[m.nonzero()] = -np.inf
-        if scores.dtype != np.float64:
-            scores = scores.astype(np.float64)
         return scores
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:

--- a/irspack/recommenders/ials.py
+++ b/irspack/recommenders/ials.py
@@ -76,10 +76,21 @@ class IALSRecommender(
 ):
     r"""Implementation of Implicit Alternating Least Squares(IALS) or Weighted Matrix Factorization(WMF).
 
-    See:
+    It tries to minimize the following loss:
+
+    .. math ::
+
+        \frac{1}{2} \sum _{u, i} c_{ui} (\mathbf{u}_u \cdot \mathbf{v}_i - \mathbb{1}_{r_{ui} > 0}) ^ 2 +
+        \frac{1}{2} \sum _u || \mathbf{u}_u || ^2 +
+        \frac{1}{2} \sum _i || \mathbf{v}_i || ^2
+
+
+    See the seminal paper:
 
         - `Collaborative filtering for implicit feedback datasets
           <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.167.5120&rep=rep1&type=pdf>`_
+
+
 
     To speed up the learning procedure, we have also implemented the conjugate gradient descent version following:
 
@@ -104,7 +115,7 @@ class IALSRecommender(
 
                 c_{ui} = 1 + \alpha r_{ui}
 
-            If "log"
+            If "log",
 
             .. math ::
 

--- a/irspack/recommenders/toppop.py
+++ b/irspack/recommenders/toppop.py
@@ -33,8 +33,8 @@ class TopPopRecommender(BaseRecommender):
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
         n_users: int = user_indices.shape[0]
-        return np.repeat(self.score, n_users, axis=0)
+        return np.repeat(self.score, n_users, axis=0).A
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:
         n_users: int = X.shape[0]
-        return np.repeat(self.score, n_users, axis=0)
+        return np.repeat(self.score, n_users, axis=0).A

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ class get_pybind_include(object):
 
 ext_modules = [
     Extension(
-        "irspack._evaluator",
+        "irspack.evaluator._core",
         ["cpp_source/evaluator.cpp"],
         include_dirs=[
             get_pybind_include(),


### PR DESCRIPTION
* Turning evaluator into another module

* made evaluator a module

* Implemented manual mask

* added guard for evaluator.cpp

* fix evaluators' arg ordering

* Added recall_with_cutoff option

* Move float64 cast to evaluator's side

* Fixed topp