### PR TITLE
Fix for config class mapping

### DIFF
--- a/irspack/recommenders/base_earlystop.py
+++ b/irspack/recommenders/base_earlystop.py
@@ -48,7 +48,6 @@ class BaseEarlyStoppingRecommenderConfig(RecommenderConfig):
 
 
 class BaseRecommenderWithEarlyStopping(BaseRecommender):
-    class_name = BaseEarlyStoppingRecommenderConfig
     """The base class for all the early-stoppable recommenders.
 
     Args:
@@ -59,6 +58,7 @@ class BaseRecommenderWithEarlyStopping(BaseRecommender):
     """
 
     trainer_class: Type[TrainerBase]
+    config_class = BaseEarlyStoppingRecommenderConfig
 
     def __init__(
         self,

--- a/irspack/recommenders/user_knn.py
+++ b/irspack/recommenders/user_knn.py
@@ -28,7 +28,7 @@ class BaseUserKNNConfig(RecommenderConfig):
 
 
 class BaseUserKNNRecommender(BaseUserSimilarityRecommender):
-    class_name = BaseUserKNNConfig
+    config_class = BaseUserKNNConfig
 
     def __init__(
         self,
@@ -116,6 +116,8 @@ class CosineUserKNNRecommender(BaseUserKNNRecommender):
             and if the variable is not set, it will be set to ``os.cpu_count()``. Defaults to None.
     """
 
+    config_class = CosineUserKNNConfig
+
     def __init__(
         self,
         X_train_all: InteractionMatrix,
@@ -180,6 +182,8 @@ class AsymmetricCosineUserKNNRecommender(BaseUserKNNRecommender):
             If ``None``, the environment variable ``"IRSPACK_NUM_THREADS_DEFAULT"`` will be looked up,
             and if the variable is not set, it will be set to ``os.cpu_count()``. Defaults to None.
     """
+
+    config_class = AsymmetricCosineUserKNNConfig
 
     def __init__(
         self,

--- a/irspack/recommenders/user_knn.py
+++ b/irspack/recommenders/user_knn.py
@@ -75,7 +75,7 @@ class BaseUserKNNRecommender(BaseUserSimilarityRecommender):
         )
 
 
-class CosineUserKNNConfig(RecommenderConfig):
+class CosineUserKNNConfig(BaseUserKNNConfig):
     normalize: bool = True
 
 
@@ -146,7 +146,7 @@ class CosineUserKNNRecommender(BaseUserKNNRecommender):
         )
 
 
-class AsymmetricCosineUserKNNConfig(RecommenderConfig):
+class AsymmetricCosineUserKNNConfig(BaseUserKNNConfig):
     alpha: float = 0.5
 
 


### PR DESCRIPTION
This PR fixes bugs related to config.

- Fix attribute name for `BaseEarlyStoppingRecommender` and `BaseUserKNNRecommender`
- Add `config_class` to `CosineUserKNNRecommender` and `AsymmetricCosineUserKNNRecommender`
- Use `BaseUserKNNConfig` as base class of `CosineUserKNNConfig` and `AsymmetricCosineUserKNNConfig`

I'm sorry that my previous PR contains these bugs, and I hope that this PR will be merged soon.