### PR TITLE
Fix NMFOptimizer's limited hyperparameter name

### DIFF
--- a/irspack/optimizers/_optimizers.py
+++ b/irspack/optimizers/_optimizers.py
@@ -122,7 +122,7 @@ try:
         ) -> List[Suggestion]:
             n_components = _get_maximal_n_components_for_budget(X, memory_budget, 512)
             return [
-                IntegerSuggestion("top_k", 4, n_components),
+                IntegerSuggestion("n_components", 4, n_components),
             ]
 
 


### PR DESCRIPTION
This PR fixes bug related to `NMFOptimizer` class.

- Change limited hyperparamter name from `top_k` to `n_components`