### PR TITLE
Add `ceil_n_heldout` option for split function.

### DIFF
--- a/irspack/dataset/__init__.py
+++ b/irspack/dataset/__init__.py
@@ -1,3 +1,4 @@
+from .amazon_music import AmazonMusicDataManager
 from .citeulike import CiteULikeADataManager
 from .movielens import (
     MovieLens1MDataManager,
@@ -10,4 +11,5 @@ __all__ = [
     "MovieLens1MDataManager",
     "MovieLens20MDataManager",
     "CiteULikeADataManager",
+    "AmazonMusicDataManager",
 ]

--- a/irspack/split/time.py
+++ b/irspack/split/time.py
@@ -10,8 +10,9 @@ def split_last_n_interaction_df(
     timestamp_column: str,
     n_heldout: Optional[int] = None,
     heldout_ratio: float = 0.1,
+    ceil_n_heldout: bool = False,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Split a dataframe holding out last `n_heldout` or
+    r"""Split a dataframe holding out last `n_heldout` or
     last `heldout_ratio` part of interactions of the users.
 
     Args:
@@ -26,6 +27,11 @@ def split_last_n_interaction_df(
         heldout_ratio :
             Specifies how much of each user interaction will be held out.
             Ignored if ``n_heldout`` is present.
+        ceil_n_heldout:
+            If this is `True` and `n_heldout` is `None`, the number of test interaction for a given user `u` will be
+            `ceil(N_u * heldout_ratio)` where `N_u` is the number of interactions fo `u`.
+            If this is `False`, `floor(N_u * heldout_ratio)` will be used instead. Defaults to `False`.
+
 
     Returns:
         First interactions and held-out interactions.
@@ -41,7 +47,12 @@ def split_last_n_interaction_df(
         n_user_appearnce = (
             df_sorted[user_column].value_counts().reindex(df_sorted[user_column].values)
         )
-        test_indicator = index_within_group <= (n_user_appearnce * heldout_ratio).values
+
+        if ceil_n_heldout:
+            n_test = np.ceil((n_user_appearnce * heldout_ratio).values)
+        else:
+            n_test = np.floor((n_user_appearnce * heldout_ratio).values)
+        test_indicator = index_within_group < n_test
     return (
         df_sorted.iloc[np.where(~test_indicator)],
         df_sorted.iloc[np.where(test_indicator)],

--- a/irspack/utils/__init__.py
+++ b/irspack/utils/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -31,7 +31,7 @@ def rowwise_train_test_split(
     X: InteractionMatrix,
     test_ratio: float = 0.5,
     n_test: Optional[int] = None,
-    ceil_n_test: bool = False,
+    ceil_n_heldout: bool = False,
     random_state: OptionalRandomState = None,
 ) -> Tuple[InteractionMatrix, InteractionMatrix]:
     """Splits the non-zero elements of a sparse matrix into two (train & test interactions).
@@ -59,7 +59,7 @@ def rowwise_train_test_split(
     X_double = X.astype(np.float64)
     if n_test is None:
         X_train_double, X_test_double = rowwise_train_test_split_by_ratio(
-            X_double, random_seed, test_ratio, ceil_n_test
+            X_double, random_seed, test_ratio, ceil_n_heldout
         )
     else:
         X_train_double, X_test_double = rowwise_train_test_split_by_fixed_n(
@@ -75,8 +75,8 @@ def df_to_sparse(
     df: pd.DataFrame,
     user_colname: str,
     item_colname: str,
-    user_ids: Optional[List[Any]] = None,
-    item_ids: Optional[List[Any]] = None,
+    user_ids: Optional[Union[List[Any], np.ndarray]] = None,
+    item_ids: Optional[Union[List[Any], np.ndarray]] = None,
     rating_colname: Optional[str] = None,
 ) -> Tuple[sps.csr_matrix, np.ndarray, np.ndarray]:
     r"""Convert pandas dataframe into sparse matrix.

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -39,7 +39,7 @@ def test_split() -> None:
 
 def test_split_ceil() -> None:
     X_1, X_2 = rowwise_train_test_split(
-        X, test_ratio=0.5, random_state=1, ceil_n_test=True
+        X, test_ratio=0.5, random_state=1, ceil_n_heldout=True
     )
     np.testing.assert_allclose(X.toarray(), (X_1 + X_2).toarray())
 


### PR DESCRIPTION
Added an option to whether to ceil/floor the number of test interactions based on split ratio.