### PR TITLE
Simplify the build script

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,6 @@ jobs:
     env:
       SKIP: no-commit-to-branch
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -17,12 +17,12 @@ jobs:
         run: |
           pip install --upgrade pip
           sudo apt-get install lcov
-          IRSPACK_TESTING=true python setup.py develop
+          CXXFLAGS="-O0 -g -coverage" pip install -e .
       - name: Run pytest
         run: |
           pip install pytest pytest-cov
           pip install lightfm jaxlib jax dm-haiku optax
-          IRSPACK_TESTING=true pytest --cov=./irspack tests/
+          pytest --cov=./irspack tests/
       - name: Generate coverage (ubuntu)
         run: |
           coverage xml

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
   push:
-    branches:
-      - main
   release:
     types:
       - created

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,9 +19,9 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Build sdist
-        run: python setup.py sdist
+        run: pip install pybind11 setuptools_scm && python setup.py sdist
       - uses: actions/upload-artifact@v2
         with:
           path: dist/*.tar.gz
@@ -56,7 +56,7 @@ jobs:
             cibw:
               arch: universal2
               build: "cp39* cp310*"
-              env: ''
+              env: ""
 
           - os: ubuntu-20.04
             name: manylinux1
@@ -129,7 +129,6 @@ jobs:
         run: python -m pip install cibuildwheel=="${{env.cibuildwheel_version}}"
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
   push:
+    branches:
+      - main
   release:
     types:
       - created

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[build-system]
+requires = [
+  "setuptools>=42",
+  "wheel",
+  "pybind11>=2.8.0",
+  "requests",
+  "setuptools_scm[toml]>=6.2",
+]
+
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 ensure_newline_before_comments = true
 force_grid_wrap = 0
@@ -10,6 +21,7 @@ use_parentheses = true
 ensure_newline_before_comments = true
 force_grid_wrap = 0
 include_trailing_comma = true
+known_third_party = ["pybind11"]
 line_length = 88
 multi_line_output = 3
 use_parentheses = true


### PR DESCRIPTION
Use newer versions of pybind11 with `Pybind11Extension` helper class.
This will make the binaries much smaller.