### PR TITLE
Build python 3.11 wheel

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,6 @@ jobs:
     env:
       SKIP: no-commit-to-branch
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -21,7 +21,7 @@ jobs:
           CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" pip install -e .
       - name: Run pytest
         run: |
-          pip install pytest pytest-mock pytest-cov
+          pip install setuptools wheel pytest pytest-mock pytest-cov
           pip install jaxlib jax dm-haiku optax
           pip install --no-use-pep517 lightfm
           pytest --cov=./src/irspack tests/

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -6,13 +6,13 @@ jobs:
     env:
       OS: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Build irspack (ubuntu)
         run: |
           pip install --upgrade pip

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Run pytest
         run: |
           pip install pytest pytest-mock pytest-cov
-          pip install lightfm jaxlib jax dm-haiku optax
+          pip install jaxlib jax dm-haiku optax
+          pip install --no-use-pep517 lightfm
           pytest --cov=./src/irspack tests/
       - name: Generate coverage (ubuntu)
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,28 +3,29 @@ on:
   push:
     branches:
       - main
+      - feature-py311
   release:
     types:
       - created
 env:
-  cibuildwheel_version: "2.7.0"
+  cibuildwheel_version: "2.13.0"
 jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: Build sdist
         run: pip install pybind11 setuptools_scm && python setup.py sdist
-      - uses: actions/upload-artifact@v2
-        with:
-          path: dist/*.tar.gz
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: dist/*.tar.gz
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -55,7 +56,7 @@ jobs:
             name: mac-arm
             cibw:
               arch: universal2
-              build: "cp39* cp310*"
+              build: "cp39* cp310* cp311*"
               env: ""
 
           - os: ubuntu-20.04
@@ -70,7 +71,7 @@ jobs:
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
-              build: "cp38* cp39* cp310*"
+              build: "cp38* cp39* cp310* cp311*"
               skip: "*musllinux*"
               manylinux_image: manylinux2014
               env: CFLAGS='-march=core-avx-i'
@@ -108,6 +109,14 @@ jobs:
               manylinux_image: manylinux2014
               arch: aarch64
 
+          - os: ubuntu-20.04
+            name: manylinux_aarch64_cp311
+            cibw:
+              build: "cp311*"
+              skip: "*musllinux*"
+              manylinux_image: manylinux2014
+              arch: aarch64
+
           - os: windows-2019
             name: win_amd64
             architecture: x64
@@ -116,10 +125,10 @@ jobs:
               env: "CL='/arch:AVX'"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
       - name: register qemu
         if: contains(matrix.cibw.arch, 'aarch64')
@@ -130,33 +139,33 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_APITOKEN }}
-          packages_dir: dist/
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
-          skip_existing: true
-      - name: Publish package to PyPI
-        if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_APITOKEN }}
-          packages_dir: dist/
-          verbose: true
-          skip_existing: true
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          path: ./wheelhouse/*.whl
+#
+#  upload_pypi:
+#    needs: [build_wheels, build_sdist]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/download-artifact@v2
+#        with:
+#          name: artifact
+#          path: dist
+#      - name: Publish package to TestPyPI
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: __token__
+#          password: ${{ secrets.TEST_PYPI_APITOKEN }}
+#          packages_dir: dist/
+#          repository_url: https://test.pypi.org/legacy/
+#          verbose: true
+#          skip_existing: true
+#      - name: Publish package to PyPI
+#        if: github.event_name == 'release'
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_APITOKEN }}
+#          packages_dir: dist/
+#          verbose: true
+#          skip_existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature-py311
   release:
     types:
       - created
@@ -23,9 +22,9 @@ jobs:
           python-version: "3.11"
       - name: Build sdist
         run: pip install pybind11 setuptools_scm && python setup.py sdist
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -139,33 +138,33 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          path: ./wheelhouse/*.whl
-#
-#  upload_pypi:
-#    needs: [build_wheels, build_sdist]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/download-artifact@v2
-#        with:
-#          name: artifact
-#          path: dist
-#      - name: Publish package to TestPyPI
-#        uses: pypa/gh-action-pypi-publish@master
-#        with:
-#          user: __token__
-#          password: ${{ secrets.TEST_PYPI_APITOKEN }}
-#          packages_dir: dist/
-#          repository_url: https://test.pypi.org/legacy/
-#          verbose: true
-#          skip_existing: true
-#      - name: Publish package to PyPI
-#        if: github.event_name == 'release'
-#        uses: pypa/gh-action-pypi-publish@master
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_APITOKEN }}
-#          packages_dir: dist/
-#          verbose: true
-#          skip_existing: true
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_APITOKEN }}
+          packages_dir: dist/
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
+          skip_existing: true
+      - name: Publish package to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_APITOKEN }}
+          packages_dir: dist/
+          verbose: true
+          skip_existing: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,20 +14,21 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790 # Use the sha / tag you want to point at
+    rev: v0.991
     hooks:
       - id: mypy
+        additional_dependencies: ['types-all']
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/hadialqattan/pycln
-    rev: v1.2.4 # Possible releases: https://github.com/hadialqattan/pycln/releases
+    rev: v2.1.3
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]

--- a/src/irspack/evaluation/_core.pyi
+++ b/src/irspack/evaluation/_core.pyi
@@ -24,7 +24,7 @@ class EvaluatorCore:
     def get_ground_truth(self) -> scipy.sparse.csr_matrix[numpy.float64]: ...
     def get_metrics_f32(
         self,
-        score_array: numpy.ndarray[numpy.float32, _Shape[m, n]],
+        score_array: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]],
         cutoff: int,
         offset: int,
         n_threads: int,
@@ -32,7 +32,7 @@ class EvaluatorCore:
     ) -> Metrics: ...
     def get_metrics_f64(
         self,
-        score_array: numpy.ndarray[numpy.float64, _Shape[m, n]],
+        score_array: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float64]],
         cutoff: int,
         offset: int,
         n_threads: int,

--- a/src/irspack/evaluation/_core.pyi
+++ b/src/irspack/evaluation/_core.pyi
@@ -1,11 +1,12 @@
 m: int
 n: int
+import typing
+
+import numpy
+import scipy.sparse
 from numpy import float32
 
 import irspack.evaluation._core
-import typing
-import numpy
-import scipy.sparse
 
 _Shape = typing.Tuple[int, ...]
 

--- a/src/irspack/recommenders/_ials.pyi
+++ b/src/irspack/recommenders/_ials.pyi
@@ -1,6 +1,5 @@
 m: int
 n: int
-from numpy import float32
 
 """irspack's core module for "IALSRecommender".
 Built to use
@@ -13,8 +12,6 @@ import numpy
 import scipy.sparse
 
 import irspack.recommenders._ials
-
-_Shape = typing.Tuple[int, ...]
 
 __all__ = [
     "CG",
@@ -85,28 +82,32 @@ class IALSTrainer:
     def step(self, arg0: IALSSolverConfig) -> None: ...
     def transform_item(
         self, arg0: scipy.sparse.csr_matrix[numpy.float32], arg1: IALSSolverConfig
-    ) -> numpy.ndarray[numpy.float32, _Shape[m, n]]: ...
+    ) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]: ...
     def transform_user(
         self, arg0: scipy.sparse.csr_matrix[numpy.float32], arg1: IALSSolverConfig
-    ) -> numpy.ndarray[numpy.float32, _Shape[m, n]]: ...
+    ) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]: ...
     def user_scores(
         self, arg0: int, arg1: int, arg2: IALSSolverConfig
-    ) -> numpy.ndarray[numpy.float32, _Shape[m, n]]: ...
+    ) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]: ...
     @property
-    def item(self) -> numpy.ndarray[numpy.float32, _Shape[m, n]]:
+    def item(self) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]:
         """
-        :type: numpy.ndarray[numpy.float32, _Shape[m, n]]
+        :type: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]
         """
     @item.setter
-    def item(self, arg0: numpy.ndarray[numpy.float32, _Shape[m, n]]) -> None:
+    def item(
+        self, arg0: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]
+    ) -> None:
         pass
     @property
-    def user(self) -> numpy.ndarray[numpy.float32, _Shape[m, n]]:
+    def user(self) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]:
         """
-        :type: numpy.ndarray[numpy.float32, _Shape[m, n]]
+        :type: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]
         """
     @user.setter
-    def user(self, arg0: numpy.ndarray[numpy.float32, _Shape[m, n]]) -> None:
+    def user(
+        self, arg0: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]]
+    ) -> None:
         pass
     pass
 

--- a/src/irspack/recommenders/_ials.pyi
+++ b/src/irspack/recommenders/_ials.pyi
@@ -6,10 +6,13 @@ from numpy import float32
 Built to use
 	SSE, SSE2"""
 from __future__ import annotations
-import irspack.recommenders._ials
+
 import typing
+
 import numpy
 import scipy.sparse
+
+import irspack.recommenders._ials
 
 _Shape = typing.Tuple[int, ...]
 

--- a/src/irspack/recommenders/_knn.pyi
+++ b/src/irspack/recommenders/_knn.pyi
@@ -1,11 +1,12 @@
 m: int
 n: int
+import typing
+
+import numpy
+import scipy.sparse
 from numpy import float32
 
 import irspack.recommenders._knn
-import typing
-import numpy
-import scipy.sparse
 
 _Shape = typing.Tuple[int, ...]
 

--- a/src/irspack/recommenders/base.py
+++ b/src/irspack/recommenders/base.py
@@ -39,10 +39,13 @@ R = TypeVar("R", bound="BaseRecommender")
 
 
 def _sparse_to_array(U: Any) -> np.ndarray:
+    res: np.ndarray
     if sps.issparse(U):
-        return U.toarray()
+        res = U.toarray()
+        return res
     else:
-        return U
+        res = U
+        return res
 
 
 class CallBeforeFitError(Exception):

--- a/src/irspack/recommenders/bpr.py
+++ b/src/irspack/recommenders/bpr.py
@@ -144,33 +144,41 @@ class BPRFMRecommender(
         return self.trainer.fm
 
     def get_score(self, index: UserIndexArray) -> np.ndarray:
-        return (
+        res: np.ndarray = (
             self.fm.user_embeddings[index].dot(self.fm.item_embeddings.T)
             + self.fm.item_biases[np.newaxis, :]
         )
+        return res
 
     def get_score_block(self, begin: int, end: int) -> np.ndarray:
-        return (
+        res: np.ndarray = (
             self.fm.user_embeddings[begin:end].dot(self.fm.item_embeddings.T)
             + self.fm.item_biases[np.newaxis, :]
         )
+        return res
 
     def get_user_embedding(self) -> DenseMatrix:
-        return self.fm.user_embeddings
+        res: DenseMatrix = self.fm.user_embeddings
+        return res
 
     def get_score_from_user_embedding(
         self, user_embedding: DenseMatrix
     ) -> DenseScoreArray:
-        return (
+        res: DenseScoreArray = (
             user_embedding.dot(self.fm.item_embeddings.T)
             + self.fm.item_biases[np.newaxis, :]
         )
+        return res
 
     def get_item_embedding(self) -> DenseMatrix:
-        return self.fm.item_embeddings
+        res: DenseMatrix = self.fm.item_embeddings
+        return res
 
     def get_score_from_item_embedding(
         self, user_indices: UserIndexArray, item_embedding: DenseMatrix
     ) -> DenseScoreArray:
         # ignore bias
-        return self.fm.user_embeddings[user_indices].dot(item_embedding.T)
+        res: DenseScoreArray = self.fm.user_embeddings[user_indices].dot(
+            item_embedding.T
+        )
+        return res

--- a/src/irspack/recommenders/ials.py
+++ b/src/irspack/recommenders/ials.py
@@ -379,9 +379,10 @@ class IALSRecommender(
         return self.trainer
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
-        return self.trainer_as_ials.core_trainer.user[user_indices].dot(
+        res: DenseScoreArray = self.trainer_as_ials.core_trainer.user[user_indices].dot(
             self.get_item_embedding().T
         )
+        return res
 
     def get_score_block(self, begin: int, end: int) -> DenseScoreArray:
         return self.trainer_as_ials.user_scores(begin, end)
@@ -396,7 +397,8 @@ class IALSRecommender(
     def get_score_from_user_embedding(
         self, user_embedding: DenseMatrix
     ) -> DenseScoreArray:
-        return user_embedding.dot(self.get_item_embedding().T)
+        res: DenseScoreArray = user_embedding.dot(self.get_item_embedding().T)
+        return res
 
     def get_item_embedding(self) -> DenseMatrix:
         return self.trainer_as_ials.core_trainer.item
@@ -439,9 +441,10 @@ class IALSRecommender(
     def get_score_from_item_embedding(
         self, user_indices: UserIndexArray, item_embedding: DenseMatrix
     ) -> DenseScoreArray:
-        return self.trainer_as_ials.core_trainer.user[user_indices].dot(
+        res: DenseScoreArray = self.trainer_as_ials.core_trainer.user[user_indices].dot(
             item_embedding.T
         )
+        return res
 
     @classmethod
     def tune_doubling_dimension(

--- a/src/irspack/recommenders/multvae.py
+++ b/src/irspack/recommenders/multvae.py
@@ -234,7 +234,7 @@ class MultVAETrainer(TrainerBase):
             )
 
             mb_arrays.append(np.asarray(mvresult.log_softmax, dtype=np.float64))
-        score_concat = np.concatenate(mb_arrays, axis=0)
+        score_concat: DenseScoreArray = np.concatenate(mb_arrays, axis=0)
         return score_concat
 
     def run_epoch(self) -> None:

--- a/src/irspack/recommenders/nmf.py
+++ b/src/irspack/recommenders/nmf.py
@@ -56,7 +56,7 @@ class NMFRecommender(BaseRecommender):
                 random_state=42,
             )
         else:
-            # argument "alpha" in NMF is not recommended since 1.0.0
+            # argument "alpha" in NMF was deprecated since 1.0.0
             nmf_model = NMF(
                 n_components=self.n_components,
                 alpha_W=self.alpha,

--- a/src/irspack/recommenders/nmf.py
+++ b/src/irspack/recommenders/nmf.py
@@ -58,7 +58,9 @@ class NMFRecommender(BaseRecommender):
         self.H = self.nmf_model.components_
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
-        return self.W[user_indices].dot(self.H)
+        res: DenseScoreArray = self.W[user_indices].dot(self.H)
+        return res
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:
-        return self.nmf_model.transform(X).dot(self.H)
+        res: DenseScoreArray = self.nmf_model.transform(X).dot(self.H)
+        return res

--- a/src/irspack/recommenders/nmf.py
+++ b/src/irspack/recommenders/nmf.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import sklearn
+from packaging import version
 from sklearn.decomposition import NMF
 
 from ..definitions import DenseScoreArray, InteractionMatrix, UserIndexArray
@@ -44,14 +46,26 @@ class NMFRecommender(BaseRecommender):
         self.init = init
 
     def _learn(self) -> None:
-        nmf_model = NMF(
-            n_components=self.n_components,
-            alpha=self.alpha,
-            init=self.init,
-            l1_ratio=self.l1_ratio,
-            beta_loss=self.beta_loss,
-            random_state=42,
-        )
+        if version.parse(sklearn.__version__) < version.parse("1.0.0"):
+            nmf_model = NMF(
+                n_components=self.n_components,
+                alpha=self.alpha,
+                init=self.init,
+                l1_ratio=self.l1_ratio,
+                beta_loss=self.beta_loss,
+                random_state=42,
+            )
+        else:
+            # argument "alpha" in NMF is not recommended since 1.0.0
+            nmf_model = NMF(
+                n_components=self.n_components,
+                alpha_W=self.alpha,
+                alpha_H=self.alpha,
+                init=self.init,
+                l1_ratio=self.l1_ratio,
+                beta_loss=self.beta_loss,
+                random_state=42,
+            )
         self.nmf_model = nmf_model
         self.nmf_model.fit(self.X_train_all)
         self.W = self.nmf_model.fit_transform(self.X_train_all.tocsr())

--- a/src/irspack/recommenders/nmf.py
+++ b/src/irspack/recommenders/nmf.py
@@ -46,26 +46,18 @@ class NMFRecommender(BaseRecommender):
         self.init = init
 
     def _learn(self) -> None:
-        if version.parse(sklearn.__version__) < version.parse("1.0.0"):
-            nmf_model = NMF(
-                n_components=self.n_components,
-                alpha=self.alpha,
-                init=self.init,
-                l1_ratio=self.l1_ratio,
-                beta_loss=self.beta_loss,
-                random_state=42,
-            )
-        else:
-            # argument "alpha" in NMF was deprecated since 1.0.0
-            nmf_model = NMF(
-                n_components=self.n_components,
-                alpha_W=self.alpha,
-                alpha_H=self.alpha,
-                init=self.init,
-                l1_ratio=self.l1_ratio,
-                beta_loss=self.beta_loss,
-                random_state=42,
-            )
+        # argument "alpha" in NMF was deprecated since 1.0.0
+        old_version = version.parse(sklearn.__version__) < version.parse("1.0.0")
+        alpha_name = "alpha" if old_version else "alpha_W"
+        params = dict(
+            n_components=self.n_components,
+            init=self.init,
+            l1_ratio=self.l1_ratio,
+            beta_loss=self.beta_loss,
+            random_state=42,
+        )
+        params[alpha_name] = self.alpha
+        nmf_model = NMF(**params)
         self.nmf_model = nmf_model
         self.nmf_model.fit(self.X_train_all)
         self.W = self.nmf_model.fit_transform(self.X_train_all.tocsr())

--- a/src/irspack/recommenders/toppop.py
+++ b/src/irspack/recommenders/toppop.py
@@ -31,7 +31,7 @@ class TopPopRecommender(BaseRecommender):
         self.score_ = None
 
     def _learn(self) -> None:
-        self.score_ = self.X_train_all.sum(axis=0).astype(np.float64)
+        self.score_ = self.X_train_all.sum(axis=0).astype(np.float64).A
 
     @property
     def score(self) -> np.ndarray:
@@ -41,8 +41,10 @@ class TopPopRecommender(BaseRecommender):
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
         n_users: int = user_indices.shape[0]
-        return np.repeat(self.score, n_users, axis=0).A
+        res: DenseScoreArray = np.repeat(self.score, n_users, axis=0)
+        return res
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:
         n_users: int = X.shape[0]
-        return np.repeat(self.score, n_users, axis=0).A
+        res: DenseScoreArray = np.repeat(self.score, n_users, axis=0)
+        return res

--- a/src/irspack/recommenders/truncsvd.py
+++ b/src/irspack/recommenders/truncsvd.py
@@ -83,13 +83,18 @@ class TruncatedSVDRecommender(
         self.z_ = self.decomposer_.fit_transform(self.X_train_all)
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
-        return self.z[user_indices].dot(self.decomposer.components_)
+        res: DenseScoreArray = self.z[user_indices].dot(self.decomposer.components_)
+        return res
 
     def get_score_block(self, begin: int, end: int) -> DenseScoreArray:
-        return self.z[begin:end].dot(self.decomposer.components_)
+        res: DenseScoreArray = self.z[begin:end].dot(self.decomposer.components_)
+        return res
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:
-        return self.decomposer.transform(X).dot(self.decomposer.components_)
+        res: DenseScoreArray = self.decomposer.transform(X).dot(
+            self.decomposer.components_
+        )
+        return res
 
     def get_user_embedding(self) -> DenseMatrix:
         return self.z
@@ -97,12 +102,15 @@ class TruncatedSVDRecommender(
     def get_score_from_user_embedding(
         self, user_embedding: DenseMatrix
     ) -> DenseScoreArray:
-        return user_embedding.dot(self.decomposer.components_)
+        res: DenseScoreArray = user_embedding.dot(self.decomposer.components_)
+        return res
 
     def get_item_embedding(self) -> DenseMatrix:
-        return self.decomposer.components_.T
+        res: DenseMatrix = self.decomposer.components_.T
+        return res
 
     def get_score_from_item_embedding(
         self, user_indices: UserIndexArray, item_embedding: DenseMatrix
     ) -> DenseScoreArray:
-        return self.z[user_indices].dot(item_embedding.T)
+        res: DenseScoreArray = self.z[user_indices].dot(item_embedding.T)
+        return res

--- a/src/irspack/split/specified.py
+++ b/src/irspack/split/specified.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from scipy import sparse as sps
 
@@ -76,6 +77,10 @@ def holdout_specific_interactions(
     flg_column = np.zeros(df.shape[0])
     flg_column[interaction_indicator] = 1
     df[flg_colname] = flg_column
+
+    v_train_users: npt.ArrayLike
+    v_val_users: npt.ArrayLike
+    v_test_users: npt.ArrayLike
 
     validatable_users = np.unique(df[flg_column > 0][user_column])
     n_validatable_users: int = validatable_users.shape[0]

--- a/src/irspack/utils/_util_cpp.pyi
+++ b/src/irspack/utils/_util_cpp.pyi
@@ -1,11 +1,12 @@
 m: int
 n: int
+import typing
+
+import numpy
+import scipy.sparse
 from numpy import float32
 
 import irspack.utils._util_cpp
-import typing
-import numpy
-import scipy.sparse
 
 _Shape = typing.Tuple[int, ...]
 

--- a/src/irspack/utils/_util_cpp.pyi
+++ b/src/irspack/utils/_util_cpp.pyi
@@ -34,7 +34,7 @@ def remove_diagonal(
     pass
 
 def retrieve_recommend_from_score_f32(
-    score: numpy.ndarray[numpy.float32, _Shape[m, n]],
+    score: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float32]],
     allowed_indices: typing.List[typing.List[int]],
     cutoff: int,
     n_threads: int = 1,
@@ -42,7 +42,7 @@ def retrieve_recommend_from_score_f32(
     pass
 
 def retrieve_recommend_from_score_f64(
-    score: numpy.ndarray[numpy.float64, _Shape[m, n]],
+    score: numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float64]],
     allowed_indices: typing.List[typing.List[int]],
     cutoff: int,
     n_threads: int = 1,
@@ -89,7 +89,7 @@ def sparse_mm_threaded(
     arg0: scipy.sparse.csr_matrix[numpy.float64],
     arg1: scipy.sparse.csc_matrix[numpy.float64],
     arg2: int,
-) -> numpy.ndarray[numpy.float64, _Shape[m, n]]:
+) -> numpy.ndarray[typing.Tuple[int, int], numpy.dtype[numpy.float64]]:
     pass
 
 def tf_idf_weight(

--- a/tests/evaluation/test_restricted_evaluator.py
+++ b/tests/evaluation/test_restricted_evaluator.py
@@ -15,7 +15,8 @@ class MockRecommender(BaseRecommender, register_class=False):
         self.scores = scores
 
     def get_score(self, user_indices: np.ndarray) -> np.ndarray:
-        return self.scores[user_indices]
+        scores: np.ndarray = self.scores[user_indices]
+        return scores
 
     def _learn(self) -> None:
         pass
@@ -28,7 +29,7 @@ def test_restriction_global(U: int, I: int, R: int) -> None:
     except:
         pytest.skip()
     rns = np.random.RandomState(42)
-    recommendable = rns.choice(np.arange(I), replace=False, size=R)
+    recommendable = rns.choice(np.arange(I), replace=False, size=R).tolist()
     scores = rns.randn(U, I)
     X_gt = (rns.rand(U, I) >= 0.3).astype(np.float64)
     evaluator_ = Evaluator(

--- a/tests/mock_recommender.py
+++ b/tests/mock_recommender.py
@@ -11,7 +11,8 @@ class MockRecommender(BaseRecommender, register_class=False):
         self.scores = scores
 
     def get_score(self, user_indices: np.ndarray) -> np.ndarray:
-        return self.scores[user_indices]
+        scores: np.ndarray = self.scores[user_indices]
+        return scores
 
     def _learn(self) -> None:
         pass

--- a/tests/optimization/test_optimizer.py
+++ b/tests/optimization/test_optimizer.py
@@ -61,6 +61,7 @@ class MockRecommender(BaseRecommender, register_class=False):
         pass
 
     def get_score(self, user_indices: UserIndexArray) -> DenseScoreArray:
+        score: DenseScoreArray
         score = self.answer[user_indices] * self.p1
         score = score + 10 * self.rns.rand(*score.shape) * (1 - self.p1)
         return score

--- a/tests/recommenders/test_bpr.py
+++ b/tests/recommenders/test_bpr.py
@@ -21,3 +21,10 @@ def test_bprFM(test_interaction_data: Dict[str, sps.csr_matrix]) -> None:
     assert score.shape == X.shape
     score_2 = rec.get_score_remove_seen_block(0, X.shape[0])
     assert np.all(np.isneginf(score_2[X.nonzero()]))
+
+    score_user_to_item = rec.get_score_from_user_embedding(rec.get_user_embedding())
+    assert score_user_to_item.shape == X.shape
+    score_item_to_user = rec.get_score_from_item_embedding(
+        np.arange(X.shape[0]), rec.get_item_embedding()
+    )
+    assert score_item_to_user.shape == X.shape

--- a/tests/recommenders/test_knn.py
+++ b/tests/recommenders/test_knn.py
@@ -143,8 +143,8 @@ def test_topk(X: sps.csr_matrix) -> None:
 def test_p3(X: sps.csr_matrix, alpha: float) -> None:
     rec = P3alphaRecommender(X, alpha=alpha, n_threads=4)
     rec.learn()
-    W: sps.csr_matrix = rec.W
-    sim = W.toarray()
+    W_csr: sps.csr_matrix = rec.W
+    W = W_csr.toarray()
 
     P_ui = np.power(X.toarray(), alpha)
     P_iu = np.power(X.T.toarray(), alpha)

--- a/tests/recommenders/test_knn.py
+++ b/tests/recommenders/test_knn.py
@@ -16,10 +16,10 @@ from irspack.recommenders.rp3 import RP3betaRecommender
 X_small = sps.csr_matrix(
     np.asfarray([[1, 1, 2, 3, 4], [0, 1, 0, 1, 0], [0, 0, 1, 0, 0], [0, 0, 0, 0, 0]])
 )
-X_many = np.random.rand(888, 512)
-X_many[X_many <= 0.9] = 0
-X_many[X_many > 0.9] = 1
-X_many = sps.csr_matrix(X_many)
+X_many_dense = np.random.rand(888, 512)
+X_many_dense[X_many_dense <= 0.9] = 0
+X_many_dense[X_many_dense > 0.9] = 1
+X_many = sps.csr_matrix(X_many_dense)
 X_many.sort_indices()
 
 X_many_dense = sps.csr_matrix(np.random.rand(133, 245))
@@ -33,7 +33,8 @@ def test_cosine(X: sps.csr_matrix, normalize: bool) -> None:
         X, shrinkage=0, n_threads=5, top_k=X.shape[1], normalize=normalize
     )
     rec.learn()
-    sim = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
     manual = X.T.toarray()  # I x U
     norm = (manual**2).sum(axis=1) ** 0.5
     manual = manual.dot(manual.T)
@@ -51,7 +52,8 @@ def test_cosine(X: sps.csr_matrix, normalize: bool) -> None:
 def test_jaccard(X: sps.csr_matrix) -> None:
     rec = JaccardKNNRecommender(X, shrinkage=0, top_k=X.shape[1], n_threads=1)
     rec.learn()
-    sim = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
     X_bin = X.copy()
     X_bin.sort_indices()
     X_bin.data[:] = 1
@@ -74,7 +76,8 @@ def test_asymmetric_cosine(X: sps.csr_matrix, alpha: float, shrinkage: float) ->
         X, shrinkage=shrinkage, alpha=alpha, n_threads=1, top_k=X.shape[1]
     )
     rec.learn()
-    sim = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
 
     manual = X.T.toarray()  # I x U
     norm = (manual**2).sum(axis=1)
@@ -102,7 +105,8 @@ def test_tversky_index(
         X, shrinkage=shrinkage, alpha=alpha, beta=beta, n_threads=1, top_k=X.shape[1]
     )
     rec.learn()
-    sim = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
     tested_index_row = RNS.randint(0, sim.shape[0], size=100)
     tested_index_col = RNS.randint(0, sim.shape[0], size=100)
     X_csc = X.tocsc()
@@ -130,7 +134,8 @@ def test_tversky_index(
 def test_topk(X: sps.csr_matrix) -> None:
     rec = CosineKNNRecommender(X, shrinkage=0, top_k=30, n_threads=5)
     rec.learn()
-    sim = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
     assert np.all((sim > 0).sum(axis=1) <= 30)
 
 
@@ -138,7 +143,8 @@ def test_topk(X: sps.csr_matrix) -> None:
 def test_p3(X: sps.csr_matrix, alpha: float) -> None:
     rec = P3alphaRecommender(X, alpha=alpha, n_threads=4)
     rec.learn()
-    W = rec.W.toarray()
+    W: sps.csr_matrix = rec.W
+    sim = W.toarray()
 
     P_ui = np.power(X.toarray(), alpha)
     P_iu = np.power(X.T.toarray(), alpha)
@@ -169,7 +175,8 @@ def test_p3(X: sps.csr_matrix, alpha: float) -> None:
 def test_rp3(X: sps.csr_matrix, alpha: float, beta: float) -> None:
     rec = RP3betaRecommender(X, alpha=alpha, beta=beta, n_threads=4)
     rec.learn()
-    W = rec.W.toarray()
+    W_csr: sps.csr_matrix = rec.W
+    W = W_csr.toarray()
     W_sum = W.sum(axis=1)
     W_sum = W_sum[W_sum >= 0]
 

--- a/tests/recommenders/test_slim.py
+++ b/tests/recommenders/test_slim.py
@@ -35,7 +35,8 @@ def test_slim_positive(test_interaction_data: Dict[str, sps.csr_matrix]) -> None
         tol=1e-8,
     )
     for iind in range(rec.W.shape[1]):
-        m = rec.W[:, iind].toarray().ravel()
+        W: sps.csr_matrix = rec.W
+        m = W[:, iind].toarray().ravel()
         Xcp = X.toarray()
         y = X[:, iind].toarray().ravel()
         Xcp[:, iind] = 0.0
@@ -68,7 +69,8 @@ def test_slim_allow_negative(test_interaction_data: Dict[str, sps.csr_matrix]) -
         alpha=alpha, l1_ratio=l1_ratio, fit_intercept=False, max_iter=ITER, tol=1e-8
     )
     for iind in range(rec.W.shape[1]):
-        m = rec.W[:, iind].toarray().ravel()
+        W: sps.csr_matrix = rec.W
+        m = W[:, iind].toarray().ravel()
         Xcp = X.toarray()
         y = X[:, iind].toarray().ravel()
         Xcp[:, iind] = 0.0
@@ -90,7 +92,8 @@ def test_slim_topk(test_interaction_data: Dict[str, sps.csr_matrix]) -> None:
         tol=0,
     )
     rec.learn()
-    W_non_restricted = rec.W.toarray()
+    W_non_restricted_csr: sps.csr_matrix = rec.W
+    W_non_restricted = W_non_restricted_csr.toarray()
 
     rec_restricted = SLIMRecommender(
         X,
@@ -103,7 +106,8 @@ def test_slim_topk(test_interaction_data: Dict[str, sps.csr_matrix]) -> None:
         top_k=1,
     )
     rec_restricted.learn()
-    W_restricted = rec_restricted.W.toarray()
+    W_restricted_csr: sps.csr_matrix = rec_restricted.W
+    W_restricted = W_restricted_csr.toarray()
     for i in range(rec.n_items):
         gt = W_non_restricted[:, i]
         target = W_restricted[:, i]

--- a/tests/recommenders/test_truncsvd.py
+++ b/tests/recommenders/test_truncsvd.py
@@ -4,10 +4,10 @@ import scipy.sparse as sps
 
 RNS = np.random.RandomState(0)
 
-X = RNS.rand(200, 512)
-X[X <= 0.9] = 0
-X[X > 0.9] = 1
-X = sps.csr_matrix(X)
+X_dense = RNS.rand(200, 512)
+X_dense[X_dense <= 0.9] = 0
+X_dense[X_dense > 0.9] = 1
+X: sps.csr_matrix = sps.csr_matrix(X_dense)
 
 
 def test_truncsvd() -> None:

--- a/tests/recommenders/test_truncsvd.py
+++ b/tests/recommenders/test_truncsvd.py
@@ -37,3 +37,12 @@ def test_truncsvd() -> None:
     X_reproduced_cold = overfit_rec.get_score_cold_user(X)
     residual_cold = (X_reproduced_cold - X).A1
     assert ((residual_cold**2).sum() / X_frobenius) < 1e-3
+
+    score_user_to_item = overfit_rec.get_score_from_user_embedding(
+        overfit_rec.get_user_embedding()
+    )
+    assert score_user_to_item.shape == X.shape
+    score_item_to_user = overfit_rec.get_score_from_item_embedding(
+        np.arange(X.shape[0]), overfit_rec.get_item_embedding()
+    )
+    assert score_item_to_user.shape == X.shape

--- a/tests/recommenders/test_user_knn.py
+++ b/tests/recommenders/test_user_knn.py
@@ -10,10 +10,10 @@ from irspack.recommenders.user_knn import (
 X_small = sps.csr_matrix(
     np.asfarray([[1, 1, 2, 3, 4], [0, 1, 0, 1, 0], [0, 0, 1, 0, 0], [0, 0, 0, 0, 0]])
 )
-X_many = np.random.rand(888, 512)
-X_many[X_many <= 0.9] = 0
-X_many[X_many > 0.9] = 1
-X_many = sps.csr_matrix(X_many)
+X_many_dense = np.random.rand(888, 512)
+X_many_dense[X_many_dense <= 0.9] = 0
+X_many_dense[X_many_dense > 0.9] = 1
+X_many = sps.csr_matrix(X_many_dense)
 X_many.sort_indices()
 
 X_many_dense = sps.csr_matrix(np.random.rand(133, 245))
@@ -29,7 +29,8 @@ def test_cosine(X: sps.csr_matrix, normalize: bool) -> None:
     with pytest.raises(RuntimeError):
         rec.U
     rec.learn()
-    sim = rec.U.toarray()
+    U: sps.csr_matrix = rec.U
+    sim = U.toarray()
     manual = X.toarray()  # U x I
     norm = (manual**2).sum(axis=1) ** 0.5
     manual = manual.dot(manual.T)
@@ -52,7 +53,8 @@ def test_asymmetric_cosine(X: sps.csr_matrix, alpha: float, shrinkage: float) ->
         X, shrinkage=shrinkage, alpha=alpha, n_threads=1, top_k=X.shape[0]
     )
     rec.learn()
-    sim = rec.U.toarray()
+    U: sps.csr_matrix = rec.U
+    sim = U.toarray()
 
     manual = X.toarray()
     norm = (manual**2).sum(axis=1)
@@ -72,5 +74,6 @@ def test_asymmetric_cosine(X: sps.csr_matrix, alpha: float, shrinkage: float) ->
 def test_topk(X: sps.csr_matrix) -> None:
     rec = AsymmetricCosineUserKNNRecommender(X, shrinkage=0, top_k=30, n_threads=5)
     rec.learn()
-    sim = rec.U.toarray()
+    U: sps.csr_matrix = rec.U
+    sim = U.toarray()
     assert np.all((sim > 0).sum(axis=1) <= 30)

--- a/tests/split/test_specific_holdout.py
+++ b/tests/split/test_specific_holdout.py
@@ -36,7 +36,7 @@ def test_holdout_particular_item_interaction() -> None:
     validatable_item_ids = np.random.choice(
         item_ids, size=len(item_ids) // 5, replace=False
     )
-    indicator = np.where(df.item_id.isin(validatable_item_ids).values)
+    indicator: np.ndarray = df.item_id.isin(validatable_item_ids).values.nonzero()
     item_id_reprod, dataset = holdout_specific_interactions(
         df,
         "user_id",
@@ -171,7 +171,7 @@ def test_holdout_future() -> None:
 
     for userset in [val_users, test_users]:
         # check all of the train_interactions are in the future
-        train_interactions = X_to_df(userset.X_train, userset.user_ids)
+        train_interactions = X_to_df(userset.X_train, np.asarray(userset.user_ids))
         train_interactions_with_ts = train_interactions.merge(
             df_master, on=["user_id", "item_id"], how="inner"
         )
@@ -179,7 +179,7 @@ def test_holdout_future() -> None:
         assert np.all(train_interactions_with_ts.timestamp.values < 0)
 
         # check all of the test_interactions are in the future
-        test_interactions = X_to_df(userset.X_test, userset.user_ids)
+        test_interactions = X_to_df(userset.X_test, np.asarray(userset.user_ids))
         test_interactions_with_ts = test_interactions.merge(
             df_master, on=["user_id", "item_id"], how="inner"
         )

--- a/tests/utils/test_id_mapper.py
+++ b/tests/utils/test_id_mapper.py
@@ -17,13 +17,14 @@ class MockRecommender(BaseRecommender):
         self.scores = scores
 
     def get_score(self, user_indices: np.ndarray) -> np.ndarray:
-        return self.scores[user_indices]
+        score: np.ndarray = self.scores[user_indices]
+        return score
 
     def _learn(self) -> None:
         pass
 
     def get_score_cold_user(self, X: InteractionMatrix) -> DenseScoreArray:
-        score = np.exp(X.toarray())
+        score: np.ndarray = np.exp(X.toarray())
         score /= score.sum(axis=1)[:, None]
         return score
 
@@ -96,7 +97,7 @@ def test_basic_usecase(dtype: str) -> None:
             rec, uid, cutoff=n_items, forbidden_item_ids=forbbiden_item
         )
         check_descending(recommended_with_restriction)
-        for iid, score in recommended_with_restriction:
+        for iid, _ in recommended_with_restriction:
             assert iid not in forbbiden_item
 
         random_allowed_items = list(
@@ -207,13 +208,12 @@ def test_basic_usecase(dtype: str) -> None:
     for i, result in enumerate(batch_result_dict):
         nnz = len(X[i].nonzero()[1])
         softmax_denom = X.shape[1] - nnz + np.exp(2) * nnz
-        for _, score in result:
-            assert score == pytest.approx(1 / softmax_denom)
+        for _, val in result:
+            assert val == pytest.approx(1 / softmax_denom)
 
 
 def test_item_id_mapper_per_user_allowed_item() -> None:
-    ids = [(i, f"{i}") for i in range(1, 11)]
-    np.random.shuffle(ids)
+    ids = [(i, f"{i}") for i in np.random.choice(10, size=10, replace=False) + 1]
     id_mapepr = ItemIDMapper(ids)
     N_users = 10
     score = np.random.random((N_users, len(ids)))
@@ -239,8 +239,7 @@ def test_item_id_mapper_per_user_allowed_item() -> None:
 
 
 def test_item_id_mapper_uniform_allowed_item() -> None:
-    ids = [(i, f"{i}") for i in range(1, 11)]
-    np.random.shuffle(ids)
+    ids = [(i, f"{i}") for i in np.random.choice(10, size=10, replace=False) + 1]
     id_mapepr = ItemIDMapper(ids)
     N_users = 10
     score = np.random.random((N_users, len(ids)))


### PR DESCRIPTION
- Build python 3.11 wheel
- Additional modifications:
  - Updated pre-commit hooks
  - Resolved mypy error
  - Avoided sklearn NMF deprecated parameter `alpha`
  - Installed lightfm using `--no-use-pep517`