### PR TITLE
Fix wheel ABI: produce .abi3.so to match cp312-abi3 wheel tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,16 +29,16 @@ include(CPack)
 
 
 # Detect the installed nanobind package and import it into CMake
-find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} ${SKBUILD_SABI_COMPONENT} REQUIRED)
 execute_process(
   COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 
-nanobind_add_module(_ials_core cpp_source/als/wrapper.cpp)
-nanobind_add_module(_knn cpp_source/knn/wrapper.cpp)
-nanobind_add_module(_util_cpp cpp_source/util.cpp)
-nanobind_add_module(_core_evaluator cpp_source/evaluator.cpp)
+nanobind_add_module(_ials_core STABLE_ABI cpp_source/als/wrapper.cpp)
+nanobind_add_module(_knn STABLE_ABI cpp_source/knn/wrapper.cpp)
+nanobind_add_module(_util_cpp STABLE_ABI cpp_source/util.cpp)
+nanobind_add_module(_core_evaluator STABLE_ABI cpp_source/evaluator.cpp)
 
 install(TARGETS _ials_core LIBRARY DESTINATION irspack/recommenders)
 install(TARGETS _core_evaluator LIBRARY DESTINATION irspack/evaluation)


### PR DESCRIPTION
## Summary

scikit-build-core tags wheels as `cp312-abi3` via `wheel.py-api = "cp312"` in `pyproject.toml`, but `nanobind_add_module(...)` without `STABLE_ABI` produces version-specific `.cpython-3X-<platform>.so` files. The resulting wheel claims abi3 compatibility in its filename but fails to load on Python 3.13/3.14 because the inner `.so` files use a CPython-3.12-only extension suffix:

```
>>> from irspack.evaluation import EvaluatorCore
ModuleNotFoundError: No module named 'irspack.evaluation._core_evaluator'
```

### Root cause

`nanobind_add_module(... STABLE_ABI ...)` silently turns `STABLE_ABI` off when `Python::SABIModule` is not a CMake target (see `nanobind-config.cmake` L368-L373). scikit-build-core already sets `SKBUILD_SABI_COMPONENT=Development.SABIModule`, but the `find_package(Python ...)` call in `CMakeLists.txt` was not forwarding it, so the SABI target was never created.

### Changes

- Pass `${SKBUILD_SABI_COMPONENT}` to `find_package(Python ...)` so the `Python::SABIModule` target exists for SABI builds.
- Add `STABLE_ABI` to each `nanobind_add_module` call so extensions are compiled against the limited API and named `.abi3.so`.

## Test plan

- [x] Local build on CPython 3.13.3 produces `_core_evaluator.abi3.so` etc.
- [x] Local build on CPython 3.14.5 produces `_core_evaluator.abi3.so` etc.
- [x] `import irspack` and `from irspack.evaluation import EvaluatorCore` succeed on both 3.13 and 3.14 from the cp312-abi3 wheel.
- [ ] CI green on all supported Python versions.