### PR TITLE
Handle feature ridge Cholesky failure gracefully in Optuna tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.2 (TBD)
+
+### Fixed
+
+- Let feature-aware iALS tuning continue when the feature ridge Cholesky
+  decomposition fails: the affected Optuna trial is recorded with the worst
+  objective value instead of aborting the entire study.
+
 ## 0.5.1 (2026-07-24)
 
 ### Added

--- a/cpp_source/als/IALSTrainer.hpp
+++ b/cpp_source/als/IALSTrainer.hpp
@@ -28,6 +28,11 @@ using FeatureMatrix = std::variant<SparseMatrix, DenseMatrix>;
 using ColMajorDenseMatrix =
     Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
 
+class FeatureRidgeCholeskyError : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
 struct FeatureWeightCache {
   DenseVector row_weights;
   Eigen::LLT<ColMajorDenseMatrix, Eigen::Lower> llt;
@@ -1102,7 +1107,8 @@ private:
     gram.diagonal().array() += lambda_feature;
     cache.llt.compute(gram);
     if (cache.llt.info() != Eigen::Success)
-      throw std::runtime_error("Feature ridge Cholesky decomposition failed.");
+      throw FeatureRidgeCholeskyError(
+          "Feature ridge Cholesky decomposition failed.");
     cache.initialized = true;
   }
 
@@ -1125,7 +1131,8 @@ private:
     gram.diagonal().array() += lambda_feature;
     cache.llt.compute(gram);
     if (cache.llt.info() != Eigen::Success)
-      throw std::runtime_error("Feature ridge Cholesky decomposition failed.");
+      throw FeatureRidgeCholeskyError(
+          "Feature ridge Cholesky decomposition failed.");
     cache.initialized = true;
   }
 

--- a/cpp_source/als/wrapper.cpp
+++ b/cpp_source/als/wrapper.cpp
@@ -22,6 +22,9 @@ NB_MODULE(_ials_core, m) {
 
   m.doc() = doc_stream.str();
 
+  nanobind::exception<FeatureRidgeCholeskyError>(
+      m, "FeatureRidgeCholeskyError", PyExc_RuntimeError);
+
   nanobind::enum_<LossType>(m, "LossType")
       .value("ORIGINAL", LossType::ORIGINAL)
       .value("IALSPP", LossType::IALSPP);

--- a/src/irspack/optimization/optimizer.py
+++ b/src/irspack/optimization/optimizer.py
@@ -90,6 +90,7 @@ class Optimizer:
         max_epoch: int = 128,
         validate_epoch: int = 5,
         score_degradation_max: int = 5,
+        trial_failure_exceptions: Tuple[Type[Exception], ...] = (),
     ):
 
         if logger is None:
@@ -107,6 +108,7 @@ class Optimizer:
         self.max_epoch = max_epoch
         self.validate_epoch = validate_epoch
         self.score_degradation_max = score_degradation_max
+        self.trial_failure_exceptions = trial_failure_exceptions
 
     def objective_function(
         self, recommender_class: Type["BaseRecommender"]
@@ -125,16 +127,27 @@ class Optimizer:
             self.logger.info("Trial %s:", trial.number)
             self.logger.info("parameter = %s", params)
 
-            recommender = recommender_class(data, **params)
-            recommender.learn_with_optimizer(
-                self.val_evaluator,
-                trial,
-                max_epoch=self.max_epoch,
-                validate_epoch=self.validate_epoch,
-                score_degradation_max=self.score_degradation_max,
-            )
+            try:
+                recommender = recommender_class(data, **params)
+                recommender.learn_with_optimizer(
+                    self.val_evaluator,
+                    trial,
+                    max_epoch=self.max_epoch,
+                    validate_epoch=self.validate_epoch,
+                    score_degradation_max=self.score_degradation_max,
+                )
 
-            score = self.val_evaluator.get_score(recommender)
+                score = self.val_evaluator.get_score(recommender)
+            except self.trial_failure_exceptions as error:
+                self.logger.warning(
+                    "Trial %s failed with a recoverable error: %s",
+                    trial.number,
+                    error,
+                )
+                trial.set_user_attr("_failure_reason", str(error))
+                score = {self.val_evaluator.target_metric.name: -float("inf")}
+                add_score_to_trial(trial, score, self.val_evaluator.cutoff)
+                return float("inf")
             end = time.time()
 
             time_spent = end - start

--- a/src/irspack/recommenders/_ials_core.pyi
+++ b/src/irspack/recommenders/_ials_core.pyi
@@ -11,6 +11,8 @@ import numpy
 import scipy
 from numpy.typing import NDArray
 
+class FeatureRidgeCholeskyError(RuntimeError): ...
+
 class LossType(enum.Enum):
     ORIGINAL = 0
 

--- a/src/irspack/recommenders/base.py
+++ b/src/irspack/recommenders/base.py
@@ -87,6 +87,7 @@ class BaseRecommender(object, metaclass=RecommenderMeta):
 
     config_class: Type[RecommenderConfig]
     default_tune_range: List[ParameterRange]
+    optuna_trial_failure_exceptions: Tuple[Type[Exception], ...] = ()
 
     X_train_all: sps.csr_matrix
     """The matrix to feed into recommender."""
@@ -278,6 +279,7 @@ class BaseRecommender(object, metaclass=RecommenderMeta):
             validate_epoch=validate_epoch,
             score_degradation_max=score_degradation_max,
             logger=logger,
+            trial_failure_exceptions=cls.optuna_trial_failure_exceptions,
         )
         return optim.optimize_with_study(study, cls, n_trials=n_trials, timeout=timeout)
 

--- a/src/irspack/recommenders/ials.py
+++ b/src/irspack/recommenders/ials.py
@@ -24,7 +24,11 @@ from ..optimization.parameter_range import (
     ParameterRange,
     UniformIntegerRange,
 )
-from ._ials_core import IALSModelConfigBuilder, IALSSolverConfigBuilder
+from ._ials_core import (
+    FeatureRidgeCholeskyError,
+    IALSModelConfigBuilder,
+    IALSSolverConfigBuilder,
+)
 from ._ials_core import IALSTrainer as CoreTrainer
 from ._ials_core import LossType, SolverType
 from .base import (
@@ -354,6 +358,7 @@ class IALSRecommender(
     """
 
     config_class = IALSConfig
+    optuna_trial_failure_exceptions = (FeatureRidgeCholeskyError,)
     default_tune_range: List[ParameterRange] = [
         UniformIntegerRange("n_components", 4, 300),
         LogUniformFloatRange("alpha0", 3e-3, 1),

--- a/tests/recommenders/test_ials.py
+++ b/tests/recommenders/test_ials.py
@@ -3,11 +3,13 @@ import pickle
 from typing import Callable, Dict, Literal, Optional, Tuple
 
 import numpy as np
+import optuna
 import pytest
 import scipy.sparse as sps
 
 from irspack.evaluation import Evaluator
 from irspack.recommenders._ials_core import (
+    FeatureRidgeCholeskyError,
     IALSModelConfigBuilder,
     IALSSolverConfigBuilder,
     IALSTrainer,
@@ -713,6 +715,50 @@ def test_ials_tuning_with_n_startup_trials(
     assert history[f"ndcg@{cutoff}"].isna().sum() == 0
     assert "train_epochs" in bp
     assert bp["train_epochs"] <= 16
+
+
+def test_ials_tuning_recovers_from_feature_ridge_cholesky_error() -> None:
+    interaction = sps.csr_matrix(np.array([[1, 0], [0, 1]], dtype=np.float32))
+    # This rank-deficient, high-magnitude feature matrix loses positive
+    # definiteness in the float32 Gram computation when the ridge term is tiny.
+    user_features = np.full((2, 2), 1e5, dtype=np.float32)
+    lambda_user_feature = 1e-45
+
+    with pytest.raises(FeatureRidgeCholeskyError):
+        IALSRecommender(
+            interaction,
+            n_components=2,
+            alpha0=0.1,
+            reg=0.01,
+            user_features=user_features,
+            lambda_user_feature=lambda_user_feature,
+            n_threads=1,
+            train_epochs=1,
+        ).learn()
+
+    study = optuna.create_study()
+    study.enqueue_trial({})
+    _, history = IALSRecommender.tune(
+        interaction,
+        Evaluator(interaction, cutoff=1),
+        study=study,
+        n_trials=1,
+        max_epoch=1,
+        n_components=2,
+        alpha0=0.1,
+        reg=0.01,
+        user_features=user_features,
+        lambda_user_feature=lambda_user_feature,
+        n_threads=1,
+    )
+
+    trial = study.trials[0]
+    assert trial.state == optuna.trial.TrialState.COMPLETE
+    assert trial.value == float("inf")
+    assert trial.user_attrs["_failure_reason"] == (
+        "Feature ridge Cholesky decomposition failed."
+    )
+    assert history.loc[trial.number, "ndcg@1"] == -float("inf")
 
 
 def test_ials_tuning_with_too_early_n_startup(


### PR DESCRIPTION
## Summary

When the feature ridge Cholesky decomposition fails during IALS hyperparameter tuning (e.g., due to numerically unstable parameter combinations), Optuna studies previously aborted entirely. This PR makes the failure recoverable: the offending trial is recorded with the worst objective value instead of crashing the study.

## Changes

- Introduced a specific `FeatureRidgeCholeskyError` exception in C++ (replacing generic `std::runtime_error`)
- Registered the exception with nanobind for Python catchability
- Added `trial_failure_exceptions` mechanism to `Optimizer` and `BaseRecommender`, allowing recommender classes to declare which exceptions should be caught and handled gracefully during tuning
- `IALSRecommender` now declares `FeatureRidgeCholeskyError` as a recoverable trial failure
- Added test coverage for both direct failure and graceful recovery during tuning